### PR TITLE
Make ```Guard::PumaRunner``` inherit from ```Puma::ControlCLI```.

### DIFF
--- a/lib/guard/puma.rb
+++ b/lib/guard/puma.rb
@@ -9,11 +9,8 @@ module Guard
     attr_reader :options, :runner
     DEFAULT_OPTIONS = {
       :port => 4000,
-      :environment => 'development',
       :start_on_start => true,
       :force_run => false,
-      :timeout => 20,
-      :debugger => false
     }
 
     def initialize(watchers = [], options = {})

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -118,19 +118,20 @@ module Guard
     private
     def puma_arg_list(options)
       options.map do |name,value|
+        value = value.to_s unless value.respond_to?(:index)
         case name
         when :binds
           value.map { |v| ["--bind", v] }
         when :config_file
-          ['--config', value]
+          ['--config', File.expand_path(value)]
         when :control_url
           ['--control', value]
         when :control_token
           ['--control-token', value]
         when :daemon
-          ['--daemon', value]
+          ['--daemon']
         when :debug
-          ['--debug', value]
+          ['--debug']
         when :directory
           ['--directory', value]
         when :environment
@@ -138,9 +139,9 @@ module Guard
         when :pidfile
           ['--pidfile', value]
         when :preload_app
-          ['--preload', value]
+          ['--preload']
         when :quiet
-          ['--quiet', value]
+          ['--quiet']
         when :restart_cmd
           ['--restart_cmd', value]
         when :state

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -99,7 +99,7 @@ module Guard
     private
     def puma_running?
       run('status')
-      return @message == "Puma is running"
+      return ["Puma is running","Puma is started"].include?(@message)
     end
 
     private

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -34,14 +34,16 @@ module Guard
     # override the usual start method otherwise puma gets launched inside guard
     def start
       unless puma_running?
-        run(:halt)
-        system %{sh -c 'cd %s && puma %s &'} % [Dir.pwd, puma_args.join(" ")]
+        @options[:pid] = spawn(['puma'].concat(puma_args).join(' '), chdir: Dir.pwd)
+        Process.detach(@options[:pid])
       end
       true
     end
 
     def halt
       run(:halt)
+      prepare_configuration
+      send_signal(:halt) unless @message == "Command halt sent success"
     end
 
     def restart

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -41,14 +41,14 @@ module Guard
     end
 
     def halt
-      run(:halt)
+      run('halt')
       prepare_configuration
-      send_signal(:halt) unless @message == "Command halt sent success"
+      send_signal('halt') unless @message == "Command halt sent success"
     end
 
     def restart
       if puma_running?
-        run(:'phased-restart')
+        run('phased-restart')
       else
         start
       end
@@ -98,7 +98,7 @@ module Guard
     # this is a nasty hack :(
     private
     def puma_running?
-      run(:status)
+      run('status')
       return @message == "Puma is running"
     end
 


### PR DESCRIPTION
This is a rewrite of ```Guard::PumaRunner``` utilizing (mostly) the same
code that pumactl uses to manage puma directly, instead of using
```Net::HTTP``` .

One immediate benefit of this is the ability to control ```puma``` with
signals  or unix sockets if available.

Currently the code is a bit ugly. It could be much more elegant if
```Puma::ControlCLI``` were a little less smelly (for example, run
should return meaningful values and take a command instead of using
```@options[:command]```.)  I intend to submit patches to Puma to reduce
said smell.

The options are now using the same options that puma uses internally,
while still respecting ```:host``` and ```:port```.  Additinally one can
specify additional arguments to the ```puma``` command via
```puma_args``` in either string or array form.

Array form looks something like this: ```:puma_args => ["-
t","16:32","--help","config.ru"]``` where each of the arguments that
would be separated by spaces are separate items in the array.

The use of puma_args is discouraged, though, as ```puma_arg_list```
should correctly build the command line arguments for every option that
puma can currently use.

For the full list of options, peruse ```@options``` in
lib/puma/cli.rb[1].

```pumactl``` normally spawns ```puma``` inside itself when you issue
start, if it's not currently running.  While this is possible inside
guard, I'm unsure how to do it gracefully, so I've overridden the start
mechanism.

There may be some other improvements/additions that I neglected to
mention.

Sponsored-by: CentroNet Marketing <http://www.centronetmarketing.com>

[1]: https://github.com/puma/puma/blob/master/lib/puma/cli.rb