### PR TITLE
If config is provided it takes precedence.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 * Update Guardfile to support new options
+* Let --config take precedence over default options
 
 ## 0.3.1
 

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -15,13 +15,19 @@ module Guard
       @quiet = options.delete(:quiet) { true }
       @options = options
 
-      puma_options = {
-        '--port' => options[:port],
-        '--control-token' => @control_token,
-        '--control' => "tcp://#{@control_url}",
-        '--environment' => options[:environment]
-      }
-      [:config, :bind, :threads].each do |opt|
+      if options[:config]
+        puma_options = {
+          '--config' => options[:config]
+        }
+      else
+        puma_options = {
+          '--port' => options[:port],
+          '--control-token' => @control_token,
+          '--control' => "tcp://#{@control_url}",
+          '--environment' => options[:environment]
+        }
+      end
+      [:bind, :threads].each do |opt|
         puma_options["--#{opt}"] = options[opt] if options[opt]
       end
       puma_options = puma_options.to_a.flatten
@@ -46,7 +52,7 @@ module Guard
     end
 
     private
-    
+
     def run_puma_command!(cmd)
       Net::HTTP.get build_uri(cmd)
       return true

--- a/spec/lib/guard/puma/runner_spec.rb
+++ b/spec/lib/guard/puma/runner_spec.rb
@@ -5,7 +5,7 @@ describe Guard::PumaRunner do
   let(:runner) { Guard::PumaRunner.new(options) }
   let(:environment) { 'development' }
   let(:port) { 4000 }
-  
+
   let(:default_options) { { :environment => environment, :port => port } }
   let(:options) { default_options }
 
@@ -14,7 +14,7 @@ describe Guard::PumaRunner do
       expect(runner.options).to eq(options)
     end
   end
-  
+
   %w(halt restart).each do |cmd|
     describe cmd do
       before do
@@ -27,7 +27,7 @@ describe Guard::PumaRunner do
       end
     end
   end
-  
+
 
   describe '#sleep_time' do
     let(:timeout) { 30 }
@@ -47,6 +47,13 @@ describe Guard::PumaRunner do
       let(:path) { "/tmp/elephants" }
       it "adds path to command" do
         expect(runner.cmd_opts).to match("--config #{path}")
+      end
+
+      context "and additional options" do
+        let(:options) {{ :config => path, :port => "4000", quiet: false }}
+        it "assumes options are set in config" do
+          expect(runner.cmd_opts).to eq("--config #{path}")
+        end
       end
     end
 


### PR DESCRIPTION
I'm sure this overlooks a number of edge cases, but hopefully this pull request can start a discussion on what else I need to consider in this patch.

Our problem was that we're specifying Puma config options in a config file. `guard-puma` *always* provides a command-line flags to the `puma` executable, which will in turn try to apply both sets of options. This would mean the app running on the default port of 4000 in addition to the one we've specified in `config/puma.rb` or an "Address already in use - bind(2) for "0.0.0.0" port XXXX" if we tried to specify the port as an option to `guard-puma`.

This change makes the assumption that if you're using a config file then you're responsible for setting all options within that file.
