### PR TITLE
Use a random control token by default

### DIFF
--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'puma/configuration'
 
 module Guard
   class PumaRunner
@@ -8,7 +9,7 @@ module Guard
     attr_reader :options, :control_url, :control_token, :cmd_opts
 
     def initialize(options)
-      @control_token = (options.delete(:control_token) || 'pumarules')
+      @control_token = options.delete(:control_token) { |_| ::Puma::Configuration.random_token }
       @control = "localhost"
       @control_port = (options.delete(:control_port) || '9293')
       @control_url = "#{@control}:#{@control_port}"

--- a/spec/lib/guard/puma/runner_spec.rb
+++ b/spec/lib/guard/puma/runner_spec.rb
@@ -54,7 +54,7 @@ describe Guard::PumaRunner do
         let(:options) {{ :config => path, :port => "4000", quiet: false, :environment => environment }}
         it "assumes options are set in config" do
           expect(runner.cmd_opts).to match("--config #{path}")
-          expect(runner.cmd_opts).to match("--control-token pumarules")
+          expect(runner.cmd_opts).to match(/--control-token [0-9a-f]{10,}/)
           expect(runner.cmd_opts).to match("--control tcp")
           expect(runner.cmd_opts).to match("--environment #{environment}")
         end


### PR DESCRIPTION
Closes #25
Fixes #25

I'm still not convinced this is really necessary, but I don't have a
good argument for not doing it either. If this ends up being a PITA for
people that happen to use the control token as part of other tests, then
we'll revisit plopping it somewhere.

I suppose they could always do their own thing in the `Guardfile`...