### PR TITLE
Support for Windows platform

### DIFF
--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -40,7 +40,8 @@ module Guard
     end
 
     def start
-      if Gem.win_platform?
+      if ENV['SHELL'].nil? && !ENV['COMSPEC'].nil?
+        # windows command prompt
         system %{cd "#{Dir.pwd}" && start "" /B cmd /C "puma #{cmd_opts}"}
       else
         system %{sh -c 'cd #{Dir.pwd} && puma #{cmd_opts} &'}

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -40,7 +40,11 @@ module Guard
     end
 
     def start
-      system %{sh -c 'cd #{Dir.pwd} && puma #{cmd_opts} &'}
+      if Gem.win_platform?
+        system %{cd "#{Dir.pwd}" && start "" /B cmd /C "puma #{cmd_opts}"}
+      else
+        system %{sh -c 'cd #{Dir.pwd} && puma #{cmd_opts} &'}
+      end
     end
 
     def halt

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -40,12 +40,8 @@ module Guard
     end
 
     def start
-      if ENV['SHELL'].nil? && !ENV['COMSPEC'].nil?
-        # windows command prompt
-        system %{cd "#{Dir.pwd}" && start "" /B cmd /C "puma #{cmd_opts}"}
-      else
-        system %{sh -c 'cd #{Dir.pwd} && puma #{cmd_opts} &'}
-      end
+      return start_windows_cmd if in_windows_cmd?
+      system %{sh -c 'cd #{Dir.pwd} && puma #{cmd_opts} &'}
     end
 
     def halt
@@ -81,5 +77,13 @@ module Guard
       URI "http://#{control_url}/#{cmd}?token=#{control_token}"
     end
 
+    def start_windows_cmd
+      system %{cd "#{Dir.pwd}" && start "" /B cmd /C "puma #{cmd_opts}"}
+    end
+  
+    def in_windows_cmd?
+      ENV['SHELL'].nil? && !ENV['COMSPEC'].nil?
+    end
+  
   end
 end


### PR DESCRIPTION
On Windows platform, Start.exe /B is closest thing to Unix background. And starting cmd /C makes cleaner exit. No extra console windows are shown.