### PR TITLE
Improve notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ end
 * `:control_token` is the token to use as authentication for the control server(optional)
 * `:control_port` is the port to use for the control server(optional)
 * `:threads` is the min:max number of threads to use. Defaults to 0:16 (optional)
+* `:notifications` is the list of notification types that will be sent. Defaults to `[:restarting, :restarted, :not_restarted, :stopped]` (optional)
 
 ## Contributing
 

--- a/lib/guard/puma.rb
+++ b/lib/guard/puma.rb
@@ -19,40 +19,56 @@ module Guard
       :start_on_start => true,
       :force_run => false,
       :timeout => 20,
-      :debugger => false
+      :debugger => false,
+      :notifications => %i[restarting restarted not_restarted stopped]
     }
 
     def initialize(options = {})
       super
       @options = DEFAULT_OPTIONS.merge(options)
+      @options[:port] = nil if @options.key?(:config)
       @runner = ::Guard::PumaRunner.new(@options)
     end
 
     def start
       server = options[:server] ? "#{options[:server]} and " : ""
-      UI.info "Guard::Puma will now start your app on port #{options[:port]} using #{server}#{options[:environment]} environment."
+      UI.info "Puma starting#{port_text} in #{server}#{options[:environment]} environment."
       runner.start if options[:start_on_start]
     end
 
     def reload
       UI.info "Restarting Puma..."
-      Notifier.notify("Puma restarting on port #{options[:port]} in #{options[:environment]} environment...", :title => "Restarting Puma...", :image => :pending)
+      if options[:notifications].include?(:restarting)
+        Notifier.notify("Puma restarting#{port_text} in #{options[:environment]} environment...", :title => "Restarting Puma...", :image => :pending)
+      end
       if runner.restart
         UI.info "Puma restarted"
-        Notifier.notify("Puma restarted on port #{options[:port]}.", :title => "Puma restarted!", :image => :success)
+        if options[:notifications].include?(:restarted)
+          Notifier.notify("Puma restarted#{port_text}.", :title => "Puma restarted!", :image => :success)
+        end
       else
         UI.info "Puma NOT restarted, check your log files."
-        Notifier.notify("Puma NOT restarted, check your log files.", :title => "Puma NOT restarted!", :image => :failed)
+        if options[:notifications].include?(:not_restarted)
+          Notifier.notify("Puma NOT restarted, check your log files.", :title => "Puma NOT restarted!", :image => :failed)
+        end
       end
     end
 
     def stop
-      Notifier.notify("Until next time...", :title => "Puma shutting down.", :image => :pending)
+      if options[:notifications].include?(:stopped)
+        Notifier.notify("Until next time...", :title => "Puma shutting down.", :image => :pending)
+      end
       runner.halt
     end
 
-    def run_on_change(paths)
+    def run_on_changes(paths)
       reload
+    end
+
+    private
+
+    def port_text
+      " on port #{options[:port]}" if options[:port]
     end
   end
 end


### PR DESCRIPTION
* Don't include port in notification message when `:config` option is setted
* Add option for notifications disabling

In GNOME DE system notifications has longer delay than Puma is restarting,
so "Restarting" notification is useless: you see notification about Puma is restarted with delay.

Also, rename `#run_on_change` to `#run_on_changes`: https://github.com/guard/guard/wiki/Upgrade-guide-for-existing-guards-to-Guard-v1.1