### PR TITLE
Improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## master
+
+* Add `pumactl` option
+* Improve `guard-compat` using (https://github.com/guard/guard-compat#migrating-your-api-calls)
+* Don't notify about start when no start
+* Don't stop Puma if it was started not by Guard
+* Remove unused `pry` dependency
+* Update versions of dependencies
+
 ## 0.4.1
 
 * Improve notifications. Via #30

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ end
 
 * `:port` is the port number to run on (default `4000`)
 * `:environment` is the environment to use (default `development`)
-* `:start_on_start` will start the server when starting Guard (default `true`)
+* `:start_on_start` will start the server when starting Guard and stop the server when reloading/stopping Guard (default `true`)
 * `:force_run` kills any process that's holding open the listen port before attempting to (re)start Puma (default `false`).
 * `:daemon` runs the server as a daemon, without any output to the terminal that ran `guard` (default `false`).
 * `:quiet` runs the server in quiet mode, suppressing output (default `true`).
@@ -44,6 +44,9 @@ end
 * `:control_token` is the token to use as authentication for the control server(optional)
 * `:control_port` is the port to use for the control server(optional)
 * `:threads` is the min:max number of threads to use. Defaults to 0:16 (optional)
+* `:pumactl` manages the server via `pumactl` executable instead of `puma` (default `false`)
+    * Incompatible with options such as `port`, `environment`, `daemon`, `bind`, `threads`
+    * Use with `config` option is preferred.
 * `:notifications` is the list of notification types that will be sent. Defaults to `[:restarting, :restarted, :not_restarted, :stopped]` (optional)
 
 ## Contributing

--- a/guard-puma.gemspec
+++ b/guard-puma.gemspec
@@ -16,8 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency              "guard", "~> 2.14"
   gem.add_dependency              "guard-compat", "~> 1.2"
   gem.add_dependency              "puma", "~> 3.6"
-  gem.add_development_dependency  "rake", "~> 10.4"
-  gem.add_development_dependency  "rspec", "~> 3.5.0"
-  gem.add_development_dependency  "guard-rspec", "~> 4.7.0"
-  gem.add_development_dependency  "pry"
+  gem.add_development_dependency  "rake", "~> 12"
+  gem.add_development_dependency  "rspec", "~> 3.7"
+  gem.add_development_dependency  "guard-rspec", "~> 4.7"
 end

--- a/lib/guard/puma.rb
+++ b/lib/guard/puma.rb
@@ -1,9 +1,6 @@
-require "guard"
-require "guard/plugin"
-require "guard/puma/runner"
-require "rbconfig"
-require "guard/puma/version"
-require "guard/compat/plugin"
+require 'guard/compat/plugin'
+require_relative 'puma/runner'
+require_relative 'puma/version'
 
 module Guard
   class Puma < Plugin
@@ -14,6 +11,7 @@ module Guard
     end
 
     DEFAULT_OPTIONS = {
+      :pumactl => false,
       :port => 4000,
       :environment => default_env,
       :start_on_start => true,
@@ -31,32 +29,48 @@ module Guard
     end
 
     def start
+      return unless options[:start_on_start]
       server = options[:server] ? "#{options[:server]} and " : ""
-      UI.info "Puma starting#{port_text} in #{server}#{options[:environment]} environment."
-      runner.start if options[:start_on_start]
+      Compat::UI.info(
+        "Puma starting#{port_text} in #{server}#{options[:environment]} environment."
+      )
+      runner.start
     end
 
     def reload
-      UI.info "Restarting Puma..."
+      Compat::UI.info "Restarting Puma..."
       if options[:notifications].include?(:restarting)
-        Notifier.notify("Puma restarting#{port_text} in #{options[:environment]} environment...", :title => "Restarting Puma...", :image => :pending)
+        Compat::UI.notify(
+          "Puma restarting#{port_text} in #{options[:environment]} environment...",
+          title: "Restarting Puma...", image: :pending
+        )
       end
       if runner.restart
-        UI.info "Puma restarted"
+        Compat::UI.info "Puma restarted"
         if options[:notifications].include?(:restarted)
-          Notifier.notify("Puma restarted#{port_text}.", :title => "Puma restarted!", :image => :success)
+          Compat::UI.notify(
+            "Puma restarted#{port_text}.",
+            title: "Puma restarted!", image: :success
+          )
         end
       else
-        UI.info "Puma NOT restarted, check your log files."
+        Compat::UI.info "Puma NOT restarted, check your log files."
         if options[:notifications].include?(:not_restarted)
-          Notifier.notify("Puma NOT restarted, check your log files.", :title => "Puma NOT restarted!", :image => :failed)
+          Compat::UI.notify(
+            "Puma NOT restarted, check your log files.",
+            title: "Puma NOT restarted!", image: :failed
+          )
         end
       end
     end
 
     def stop
+      return unless options[:start_on_start]
       if options[:notifications].include?(:stopped)
-        Notifier.notify("Until next time...", :title => "Puma shutting down.", :image => :pending)
+        Compat::UI.notify(
+          "Until next time...",
+          title: "Puma shutting down.", image: :pending
+        )
       end
       runner.halt
     end

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -6,49 +6,50 @@ module Guard
 
     MAX_WAIT_COUNT = 20
 
-    attr_reader :options, :control_url, :control_token, :cmd_opts
+    attr_reader :options, :control_url, :control_token, :cmd_opts, :pumactl
 
     def initialize(options)
       @control_token = options.delete(:control_token) { |_| ::Puma::Configuration.random_token }
-      @control = "localhost"
       @control_port = (options.delete(:control_port) || '9293')
-      @control_url = "#{@control}:#{@control_port}"
+      @control_url = "localhost:#{@control_port}"
       @quiet = options.delete(:quiet) { true }
+      @pumactl = options.delete(:pumactl) { false }
       @options = options
 
-      puma_options = if options[:config]
-        {
-          '--config' => options[:config],
-          '--control-token' => @control_token,
-          '--control' => "tcp://#{@control_url}",
-          '--environment' => options[:environment]
-        }
+      puma_options = {
+        (pumactl ? '--config-file' : '--config') => options[:config],
+        '--control-token' => @control_token,
+        (pumactl ? '--control-url' : '--control') => "tcp://#{@control_url}"
+      }
+      if options[:config]
+        puma_options['--config'] = options[:config]
       else
-        {
-          '--port' => options[:port],
-          '--control-token' => @control_token,
-          '--control' => "tcp://#{@control_url}",
-          '--environment' => options[:environment]
-        }
+        puma_options['--port'] = options[:port]
       end
-      [:bind, :threads].each do |opt|
-        puma_options["--#{opt}"] = options[opt] if options[opt]
+      %i[bind threads environment].each do |opt|
+        next unless options[opt]
+        if pumactl
+          next Compat::UI.warning(
+            "`#{opt}` option is not compatible with `pumactl` option"
+          )
+        end
+        puma_options["--#{opt}"] = options[opt]
       end
       puma_options = puma_options.to_a.flatten
-      puma_options << '-q' if @quiet
+      puma_options << '--quiet' if @quiet
       @cmd_opts = puma_options.join ' '
     end
 
     def start
-      if in_windows_cmd?
-        Kernel.system windows_start_cmd
-      else
-        Kernel.system nix_start_cmd
-      end
+      Kernel.system build_command('start')
     end
 
     def halt
-      Net::HTTP.get build_uri('halt')
+      if pumactl
+        Kernel.system build_command('halt')
+      else
+        Net::HTTP.get build_uri('halt')
+      end
       # server may not have been stopped correctly, but we are halting so who cares.
       return true
     end
@@ -69,7 +70,11 @@ module Guard
     private
 
     def run_puma_command!(cmd)
-      Net::HTTP.get build_uri(cmd)
+      if pumactl
+        Kernel.system build_command(cmd)
+      else
+        Net::HTTP.get build_uri(cmd)
+      end
       return true
     rescue Errno::ECONNREFUSED => e
       # server may not have been started correctly.
@@ -80,12 +85,22 @@ module Guard
       URI "http://#{control_url}/#{cmd}?token=#{control_token}"
     end
 
-    def nix_start_cmd
-      %{sh -c 'cd #{Dir.pwd} && puma #{cmd_opts} &'}
+    def build_command(cmd)
+      puma_cmd = "#{pumactl ? 'pumactl' : 'puma'} #{cmd_opts} #{cmd if pumactl}"
+      background = cmd == 'start'
+      if in_windows_cmd?
+        windows_cmd(puma_cmd, background)
+      else
+        nix_cmd(puma_cmd, background)
+      end
     end
 
-    def windows_start_cmd
-      %{cd "#{Dir.pwd}" && start "" /B cmd /C "puma #{cmd_opts}"}
+    def nix_cmd(puma_cmd, background = false)
+      %(sh -c 'cd #{Dir.pwd} && #{puma_cmd} #{'&' if background}')
+    end
+
+    def windows_cmd(puma_cmd, background = false)
+      %(cd "#{Dir.pwd}" && #{'start "" /B' if background} cmd /C "#{puma_cmd}")
     end
 
     def in_windows_cmd?

--- a/spec/lib/guard/puma/runner_spec.rb
+++ b/spec/lib/guard/puma/runner_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper'
 require 'guard/puma/runner'
-require 'pry'
 
 describe Guard::PumaRunner do
   let(:runner) { Guard::PumaRunner.new(options) }
   let(:environment) { 'development' }
   let(:port) { 4000 }
 
-  let(:default_options) { { :environment => environment, :port => port } }
+  let(:default_options) { { environment: environment, port: port } }
   let(:options) { default_options }
 
   describe "#initialize" do
@@ -16,39 +15,61 @@ describe Guard::PumaRunner do
     end
   end
 
-  %w(halt restart).each do |cmd|
+  %w[halt restart].each do |cmd|
     describe cmd do
-      before do
-        allow(runner).to receive(:build_uri).with(cmd).and_return(uri)
+      context "without pumactl" do
+        let(:options) { { pumactl: false } }
+
+        let(:uri) do
+          URI(
+            "http://#{runner.control_url}/#{cmd}?token=#{runner.control_token}"
+          )
+        end
+
+        it "#{cmd}s" do
+          expect(Net::HTTP).to receive(:get).with(uri).once
+          runner.public_send(cmd)
+        end
       end
-      let(:uri) { URI("http://#{runner.control_url}/#{cmd}?token=#{runner.control_token}") }
-      it "#{cmd}s" do
-        expect(Net::HTTP).to receive(:get).with(uri).once
-        runner.send(cmd.intern)
+
+      context "with pumactl" do
+        let(:options) { { pumactl: true } }
+
+        before do
+          allow(runner).to receive(:in_windows_cmd?).and_return(false)
+        end
+
+        let(:command) do
+          %(sh -c 'cd #{Dir.pwd} && pumactl #{runner.cmd_opts} #{cmd} ')
+        end
+
+        it "#{cmd}s" do
+          expect(Kernel).to receive(:system).with(command).once
+          runner.public_send(cmd)
+        end
       end
     end
   end
 
-  describe '#start' do
+  describe "#start" do
     context "when on Windows" do
       before do
         allow(runner).to receive(:in_windows_cmd?).and_return(true)
-        allow(runner).to receive(:windows_start_cmd).and_return("echo 'windows'")
       end
 
       it "runs the Windows command" do
-        expect(Kernel).to receive(:system).with("echo 'windows'")
+        expect(Kernel).to receive(:system).with(%r{cmd /C ".+"})
         runner.start
       end
     end
 
     context "when on *nix" do
       before do
-        allow(runner).to receive(:nix_start_cmd).and_return("echo 'nix'")
+        allow(runner).to receive(:in_windows_cmd?).and_return(false)
       end
 
       it "runs the *nix command" do
-        expect(Kernel).to receive(:system).with("echo 'nix'")
+        expect(Kernel).to receive(:system).with(/sh -c '.+'/)
         runner.start
       end
     end
@@ -69,45 +90,127 @@ describe Guard::PumaRunner do
     let(:command) { runner.start }
 
     context "with config" do
-      let(:options) {{ :config => path }}
       let(:path) { "/tmp/elephants" }
       let(:environment) { "special_dev" }
-      it "adds path to command" do
-        expect(runner.cmd_opts).to match("--config #{path}")
+
+      context "without pumactl" do
+        let(:options) { { config: path, pumactl: false } }
+
+        it "adds path to command" do
+          expect(runner.cmd_opts).to match("--config #{path}")
+        end
+
+        context "and additional options" do
+          let(:options) do
+            {
+              config: path, port: "4000",
+              quiet: false, environment: environment
+            }
+          end
+
+          it "assumes options are set in config" do
+            expect(runner.cmd_opts).to match("--config #{path}")
+            expect(runner.cmd_opts).to match(/--control-token [0-9a-f]{10,}/)
+            expect(runner.cmd_opts).to match("--control tcp")
+            expect(runner.cmd_opts).to match("--environment #{environment}")
+          end
+        end
       end
 
-      context "and additional options" do
-        let(:options) {{ :config => path, :port => "4000", quiet: false, :environment => environment }}
-        it "assumes options are set in config" do
-          expect(runner.cmd_opts).to match("--config #{path}")
-          expect(runner.cmd_opts).to match(/--control-token [0-9a-f]{10,}/)
-          expect(runner.cmd_opts).to match("--control tcp")
-          expect(runner.cmd_opts).to match("--environment #{environment}")
+      context "with pumactl" do
+        let(:options) { { config: path, pumactl: true } }
+
+        it "adds path to command" do
+          expect(runner.cmd_opts).to match("--config-file #{path}")
+        end
+
+        context "and additional options" do
+          let(:options) do
+            {
+              pumactl: true,
+              config: path, port: "4000",
+              quiet: false
+            }
+          end
+
+          it "assumes options are set in config" do
+            expect(runner.cmd_opts).to match("--config-file #{path}")
+            expect(runner.cmd_opts).to match(/--control-token [0-9a-f]{10,}/)
+            expect(runner.cmd_opts).to match("--control-url tcp")
+          end
         end
       end
     end
 
     context "with bind" do
-      let(:options) {{ :bind => uri }}
       let(:uri) { "tcp://foo" }
-      it "adds uri option to command" do
-        expect(runner.cmd_opts).to match("--bind #{uri}")
+
+      context "without pumactl" do
+        let(:options) { { pumactl: false, bind: uri } }
+
+        it "adds uri option to command" do
+          expect(runner.cmd_opts).to match("--bind #{uri}")
+        end
+      end
+
+      context "with pumactl" do
+        let(:options) { { pumactl: true, bind: uri } }
+
+        it "raises ArgumentError about incompatible options" do
+          expect(Guard::Compat::UI).to receive(:warning).with(/bind.+pumactl/)
+          runner.cmd_opts
+        end
       end
     end
 
     context "with control_token" do
-      let(:options) {{ :control_token => token }}
       let(:token) { "imma-token" }
+      let(:options) { { control_token: token } }
+
       it "adds token to command" do
         expect(runner.cmd_opts).to match(/--control-token #{token}/)
       end
     end
 
     context "with threads" do
-      let(:options) {{ :threads => threads }}
       let(:threads) { "13:42" }
-      it "adds path to command" do
-        expect(runner.cmd_opts).to match("--threads #{threads}")
+
+      context "without pumactl" do
+        let(:options) { { pumactl: false, threads: threads } }
+
+        it "adds threads option to command" do
+          expect(runner.cmd_opts).to match("--threads #{threads}")
+        end
+      end
+
+      context "with pumactl" do
+        let(:options) { { pumactl: true, threads: threads } }
+
+        it "raises ArgumentError about incompatible options" do
+          expect(Guard::Compat::UI).to receive(:warning).with(/threads.+pumactl/)
+          runner.cmd_opts
+        end
+      end
+    end
+
+    context "with environment" do
+      let(:environment) { "development" }
+
+      context "without pumactl" do
+        let(:options) { { pumactl: false, environment: environment } }
+
+        it "adds environment option to command" do
+          expect(runner.cmd_opts).to match("--environment #{environment}")
+        end
+      end
+
+      context "with pumactl" do
+        let(:options) { { pumactl: true, environment: environment } }
+
+        it "warns about incompatible options" do
+          expect(Guard::Compat::UI).to receive(:warning).with(/environment.+pumactl/)
+          runner.cmd_opts
+        end
       end
     end
   end

--- a/spec/lib/guard/puma_spec.rb
+++ b/spec/lib/guard/puma_spec.rb
@@ -57,19 +57,20 @@ describe Guard::Puma do
   end
 
   describe '#start' do
-
-    context 'start on start' do
+    context "start on start" do
       it "runs startup" do
-        expect(guard).to receive(:start).once
+        expect(guard.runner).to receive(:start).once
+        expect(Guard::Compat::UI).to receive(:info).with(/Puma starting/)
         guard.start
       end
     end
 
-    context 'no start on start' do
-      let(:options) { { :start_on_start => false } }
+    context "no start on start" do
+      let(:options) { { start_on_start: false } }
 
-      it "shows the right message and not run startup" do
-        expect(guard.runner).to receive(:start).never
+      it "doesn't show the message and not run startup" do
+        expect(guard.runner).not_to receive(:start)
+        expect(Guard::Compat::UI).not_to receive(:info).with(/Puma starting/)
         guard.start
       end
     end
@@ -81,16 +82,17 @@ describe Guard::Puma do
 
       context "when no config option set" do
         it "contains port" do
-          expect(Guard::UI).to receive(:info).with(/starting on port 4000/)
+          expect(Guard::Compat::UI).to receive(:info)
+            .with(/starting on port 4000/)
           guard.start
         end
       end
 
       context "when config option set" do
-        let(:options) { { :config => 'config.rb' } }
+        let(:options) { { config: 'config.rb' } }
 
         it "doesn't contain port" do
-          expect(Guard::UI).to receive(:info).with(/starting/)
+          expect(Guard::Compat::UI).to receive(:info).with(/starting/)
           guard.start
         end
       end
@@ -98,25 +100,23 @@ describe Guard::Puma do
   end
 
   describe '#reload' do
-
     before do
-      expect(Guard::UI).to receive(:info).with('Restarting Puma...')
-      expect(Guard::UI).to receive(:info).with('Puma restarted')
+      expect(Guard::Compat::UI).to receive(:info).with('Restarting Puma...')
+      expect(Guard::Compat::UI).to receive(:info).with('Puma restarted')
       allow(guard.runner).to receive(:restart).and_return(true)
+      allow_any_instance_of(Guard::PumaRunner).to receive(:halt)
     end
-
-    let(:runner_stub) { allow_any_instance_of(Guard::PumaRunner).to receive(:halt) }
 
     context "with default options" do
       it "restarts and show the message" do
-        expect(Guard::Notifier).to receive(:notify).with(
+        expect(Guard::Compat::UI).to receive(:notify).with(
           /restarting on port 4000/,
-          hash_including(:title => "Restarting Puma...", :image => :pending)
+          hash_including(title: "Restarting Puma...", image: :pending)
         )
 
-        expect(Guard::Notifier).to receive(:notify).with(
+        expect(Guard::Compat::UI).to receive(:notify).with(
           "Puma restarted on port 4000.",
-          hash_including(:title => "Puma restarted!", :image => :success)
+          hash_including(title: "Puma restarted!", image: :success)
         )
 
         guard.reload
@@ -124,17 +124,17 @@ describe Guard::Puma do
     end
 
     context "with config option set" do
-      let(:options) { { :config => "config.rb" } }
+      let(:options) { { config: "config.rb" } }
 
       it "restarts and show the message" do
-        expect(Guard::Notifier).to receive(:notify).with(
+        expect(Guard::Compat::UI).to receive(:notify).with(
           /restarting/,
-          hash_including(:title => "Restarting Puma...", :image => :pending)
+          hash_including(title: "Restarting Puma...", image: :pending)
         )
 
-        expect(Guard::Notifier).to receive(:notify).with(
+        expect(Guard::Compat::UI).to receive(:notify).with(
           "Puma restarted.",
-          hash_including(:title => "Puma restarted!", :image => :success)
+          hash_including(title: "Puma restarted!", image: :success)
         )
 
         guard.reload
@@ -142,21 +142,22 @@ describe Guard::Puma do
     end
 
     context "with custom :notifications option" do
-      let(:options) { { :notifications => [:restarted] } }
+      let(:options) { { notifications: [:restarted] } }
 
       it "restarts and show the message only about restarted" do
-        expect(Guard::Notifier).not_to receive(:notify).with(/restarting/)
-        expect(Guard::Notifier).to receive(:notify).with(/restarted/, kind_of(Hash))
+        expect(Guard::Compat::UI).not_to receive(:notify).with(/restarting/)
+        expect(Guard::Compat::UI).to receive(:notify)
+          .with(/restarted/, kind_of(Hash))
 
         guard.reload
       end
     end
 
     context "with empty :notifications option" do
-      let(:options) { { :notifications => [] } }
+      let(:options) { { notifications: [] } }
 
       it "restarts and doesn't show the message" do
-        expect(Guard::Notifier).not_to receive(:notify)
+        expect(Guard::Compat::UI).not_to receive(:notify)
 
         guard.reload
       end
@@ -167,18 +168,38 @@ describe Guard::Puma do
   describe '#stop' do
     context "with default options" do
       it "stops correctly with notification" do
-        expect(Guard::Notifier).to receive(:notify).with('Until next time...', anything)
+        expect(Guard::Compat::UI).to receive(:notify)
+          .with('Until next time...', anything)
         expect(guard.runner).to receive(:halt).once
         guard.stop
       end
     end
 
     context "with custom :notifications option" do
-      let(:options) { { :notifications => [] } }
+      let(:options) { { notifications: [] } }
 
       it "stops correctly without notification" do
-        expect(Guard::Notifier).not_to receive(:notify)
+        expect(Guard::Compat::UI).not_to receive(:notify)
         expect(guard.runner).to receive(:halt).once
+        guard.stop
+      end
+    end
+
+    context "start on start" do
+      it "stops correctly with notification" do
+        expect(guard.runner).to receive(:halt).once
+        expect(Guard::Compat::UI).to receive(:notify)
+          .with('Until next time...', anything)
+        guard.stop
+      end
+    end
+
+    context "no start on start" do
+      let(:options) { { start_on_start: false } }
+
+      it "doesn't show the message and not run startup" do
+        expect(guard.runner).not_to receive(:halt)
+        expect(Guard::Compat::UI).not_to receive(:notify)
         guard.stop
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,5 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.mock_with :rspec
+  config.color = true
 end


### PR DESCRIPTION
* Add `pumactl` option
* Improve `guard-compat` using (https://github.com/guard/guard-compat#migrating-your-api-calls)
* Don't notify about start when no start
* Don't stop Puma if it was started not by Guard
* Remove unused `pry` dependency
* Update versions of dependencies