### PR TITLE
Update --control to --control-url for Puma >= 5.0.0

### DIFF
--- a/guard-puma.gemspec
+++ b/guard-puma.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = Guard::PumaVersion::VERSION
   gem.add_dependency              "guard", "~> 2.14"
   gem.add_dependency              "guard-compat", "~> 1.2"
-  gem.add_dependency              "puma", "~> 4.0"
+  gem.add_dependency              "puma", ">= 4.0"
   gem.add_development_dependency  "rake", "~> 12"
   gem.add_development_dependency  "rspec", "~> 3.7"
   gem.add_development_dependency  "guard-rspec", "~> 4.7"

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -78,7 +78,7 @@ module Guard
       }.freeze,
       false => {
         config:      '--config',
-        control_url: '--control-url'
+        control_url: Gem::Version.new(Puma::Const::PUMA_VERSION) >= Gem::Version.new('5.0.0') ? '--control-url' : '--control'
       }.freeze
     }.freeze
 

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -78,7 +78,7 @@ module Guard
       }.freeze,
       false => {
         config:      '--config',
-        control_url: '--control'
+        control_url: '--control-url'
       }.freeze
     }.freeze
 

--- a/spec/lib/guard/puma/runner_spec.rb
+++ b/spec/lib/guard/puma/runner_spec.rb
@@ -18,7 +18,7 @@ describe Guard::PumaRunner do
       runner = described_class.new(options.merge(control_token: "abc"))
       expect(runner.cmd_opts).to include("--config - ")
       expect(runner.cmd_opts).to include("--control-token abc")
-      expect(runner.cmd_opts).to include("--control tcp://localhost:9293")
+      expect(runner.cmd_opts).to include("--control-url tcp://localhost:9293")
       expect(runner.cmd_opts).to include("--port 4000")
       expect(runner.cmd_opts).to include("--environment development")
       expect(runner.cmd_opts).to include("--quiet")
@@ -132,7 +132,7 @@ describe Guard::PumaRunner do
           it "assumes options are set in config" do
             expect(runner.cmd_opts).to match("--config #{path}")
             expect(runner.cmd_opts).to match(/--control-token [0-9a-f]{10,}/)
-            expect(runner.cmd_opts).to match("--control tcp")
+            expect(runner.cmd_opts).to match("--control-url tcp")
             expect(runner.cmd_opts).to match("--environment #{environment}")
           end
         end

--- a/spec/lib/guard/puma/runner_spec.rb
+++ b/spec/lib/guard/puma/runner_spec.rb
@@ -18,7 +18,7 @@ describe Guard::PumaRunner do
       runner = described_class.new(options.merge(control_token: "abc"))
       expect(runner.cmd_opts).to include("--config - ")
       expect(runner.cmd_opts).to include("--control-token abc")
-      expect(runner.cmd_opts).to include("--control-url tcp://localhost:9293")
+      expect(runner.cmd_opts).to include("--control tcp://localhost:9293")
       expect(runner.cmd_opts).to include("--port 4000")
       expect(runner.cmd_opts).to include("--environment development")
       expect(runner.cmd_opts).to include("--quiet")
@@ -132,7 +132,7 @@ describe Guard::PumaRunner do
           it "assumes options are set in config" do
             expect(runner.cmd_opts).to match("--config #{path}")
             expect(runner.cmd_opts).to match(/--control-token [0-9a-f]{10,}/)
-            expect(runner.cmd_opts).to match("--control-url tcp")
+            expect(runner.cmd_opts).to match("--control tcp")
             expect(runner.cmd_opts).to match("--environment #{environment}")
           end
         end


### PR DESCRIPTION
In Puma 5.0.0, `--control` is now an ambiguous argument, deprecated in favor of `--control-url`. This PR makes it so guard-puma will use `--control-url` on Puma 5.0.0.


see https://github.com/puma/puma/blob/master/History.md#500--2020-09-17