### PR TITLE
Puma 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
   - 2.7.0-preview1
   - rbx
   - jruby-9.2.2.0
+env:
+- PUMA_VERSION="~> 5.0"
+- PUMA_VERSION="~> 4.0"
 matrix:
   allow_failures:
     - rvm: rbx

--- a/guard-puma.gemspec
+++ b/guard-puma.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = Guard::PumaVersion::VERSION
   gem.add_dependency              "guard", "~> 2.14"
   gem.add_dependency              "guard-compat", "~> 1.2"
-  gem.add_dependency              "puma", "~> 4.0"
+  gem.add_dependency              "puma", ">= 4.0"
   gem.add_development_dependency  "rake", "~> 12"
   gem.add_development_dependency  "rspec", "~> 3.7"
   gem.add_development_dependency  "guard-rspec", "~> 4.7"

--- a/guard-puma.gemspec
+++ b/guard-puma.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = Guard::PumaVersion::VERSION
   gem.add_dependency              "guard", "~> 2.14"
   gem.add_dependency              "guard-compat", "~> 1.2"
-  gem.add_dependency              "puma", ">= 4.0"
+  gem.add_dependency              "puma", ENV["PUMA_VERSION"] || ">= 4.0"
   gem.add_development_dependency  "rake", "~> 12"
   gem.add_development_dependency  "rspec", "~> 3.7"
   gem.add_development_dependency  "guard-rspec", "~> 4.7"

--- a/guard-puma.gemspec
+++ b/guard-puma.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = Guard::PumaVersion::VERSION
   gem.add_dependency              "guard", "~> 2.14"
   gem.add_dependency              "guard-compat", "~> 1.2"
-  gem.add_dependency              "puma", ENV["PUMA_VERSION"] || ">= 4.0"
+  gem.add_dependency              "puma", ENV["PUMA_VERSION"] || [">= 4.0", "< 6"]
   gem.add_development_dependency  "rake", "~> 12"
   gem.add_development_dependency  "rspec", "~> 3.7"
   gem.add_development_dependency  "guard-rspec", "~> 4.7"

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -78,7 +78,7 @@ module Guard
       }.freeze,
       false => {
         config:      '--config',
-        control_url: '--control-url'
+        control_url: Gem::Version.new(Puma::Const::PUMA_VERSION) >= Gem::Version.new('5.0.0') ? '--control-url' : '--control'
       }.freeze
     }.freeze
 

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -78,7 +78,7 @@ module Guard
       }.freeze,
       false => {
         config:      '--config',
-        control_url: Gem::Version.new(Puma::Const::PUMA_VERSION) >= Gem::Version.new('5.0.0') ? '--control-url' : '--control'
+        control_url: '--control-url',
       }.freeze
     }.freeze
 

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -78,7 +78,7 @@ module Guard
       }.freeze,
       false => {
         config:      '--config',
-        control_url: '--control'
+        control_url: '--control-url'
       }.freeze
     }.freeze
 

--- a/spec/lib/guard/puma/runner_spec.rb
+++ b/spec/lib/guard/puma/runner_spec.rb
@@ -18,11 +18,7 @@ describe Guard::PumaRunner do
       runner = described_class.new(options.merge(control_token: "abc"))
       expect(runner.cmd_opts).to include("--config - ")
       expect(runner.cmd_opts).to include("--control-token abc")
-      if Gem::Version.new(Puma::Const::PUMA_VERSION) >= Gem::Version.new('5.0.0')
-        expect(runner.cmd_opts).to include("--control-url tcp://localhost:9293")
-      else
-        expect(runner.cmd_opts).to include("--control tcp://localhost:9293")
-      end
+      expect(runner.cmd_opts).to include("--control-url tcp://localhost:9293")
       expect(runner.cmd_opts).to include("--port 4000")
       expect(runner.cmd_opts).to include("--environment development")
       expect(runner.cmd_opts).to include("--quiet")
@@ -136,11 +132,7 @@ describe Guard::PumaRunner do
           it "assumes options are set in config" do
             expect(runner.cmd_opts).to match("--config #{path}")
             expect(runner.cmd_opts).to match(/--control-token [0-9a-f]{10,}/)
-            if Gem::Version.new(Puma::Const::PUMA_VERSION) >= Gem::Version.new('5.0.0')
-              expect(runner.cmd_opts).to match("--control-url tcp")
-            else
-              expect(runner.cmd_opts).to match("--control tcp")
-            end
+            expect(runner.cmd_opts).to match("--control-url tcp")
             expect(runner.cmd_opts).to match("--environment #{environment}")
           end
         end

--- a/spec/lib/guard/puma/runner_spec.rb
+++ b/spec/lib/guard/puma/runner_spec.rb
@@ -18,7 +18,7 @@ describe Guard::PumaRunner do
       runner = described_class.new(options.merge(control_token: "abc"))
       expect(runner.cmd_opts).to include("--config - ")
       expect(runner.cmd_opts).to include("--control-token abc")
-      expect(runner.cmd_opts).to include("--control tcp://localhost:9293")
+      expect(runner.cmd_opts).to include("--control-url tcp://localhost:9293")
       expect(runner.cmd_opts).to include("--port 4000")
       expect(runner.cmd_opts).to include("--environment development")
       expect(runner.cmd_opts).to include("--quiet")
@@ -132,7 +132,7 @@ describe Guard::PumaRunner do
           it "assumes options are set in config" do
             expect(runner.cmd_opts).to match("--config #{path}")
             expect(runner.cmd_opts).to match(/--control-token [0-9a-f]{10,}/)
-            expect(runner.cmd_opts).to match("--control tcp")
+            expect(runner.cmd_opts).to match("--control-url tcp")
             expect(runner.cmd_opts).to match("--environment #{environment}")
           end
         end

--- a/spec/lib/guard/puma/runner_spec.rb
+++ b/spec/lib/guard/puma/runner_spec.rb
@@ -18,7 +18,11 @@ describe Guard::PumaRunner do
       runner = described_class.new(options.merge(control_token: "abc"))
       expect(runner.cmd_opts).to include("--config - ")
       expect(runner.cmd_opts).to include("--control-token abc")
-      expect(runner.cmd_opts).to include("--control-url tcp://localhost:9293")
+      if Gem::Version.new(Puma::Const::PUMA_VERSION) >= Gem::Version.new('5.0.0')
+        expect(runner.cmd_opts).to include("--control-url tcp://localhost:9293")
+      else
+        expect(runner.cmd_opts).to include("--control tcp://localhost:9293")
+      end
       expect(runner.cmd_opts).to include("--port 4000")
       expect(runner.cmd_opts).to include("--environment development")
       expect(runner.cmd_opts).to include("--quiet")
@@ -132,7 +136,11 @@ describe Guard::PumaRunner do
           it "assumes options are set in config" do
             expect(runner.cmd_opts).to match("--config #{path}")
             expect(runner.cmd_opts).to match(/--control-token [0-9a-f]{10,}/)
-            expect(runner.cmd_opts).to match("--control-url tcp")
+            if Gem::Version.new(Puma::Const::PUMA_VERSION) >= Gem::Version.new('5.0.0')
+              expect(runner.cmd_opts).to match("--control-url tcp")
+            else
+              expect(runner.cmd_opts).to match("--control tcp")
+            end
             expect(runner.cmd_opts).to match("--environment #{environment}")
           end
         end

--- a/spec/lib/guard/puma/runner_spec.rb
+++ b/spec/lib/guard/puma/runner_spec.rb
@@ -18,7 +18,7 @@ describe Guard::PumaRunner do
       runner = described_class.new(options.merge(control_token: "abc"))
       expect(runner.cmd_opts).to include("--config - ")
       expect(runner.cmd_opts).to include("--control-token abc")
-      expect(runner.cmd_opts).to include("--control-url tcp://localhost:9293")
+      expect(runner.cmd_opts).to include("--control tcp://localhost:9293")
       expect(runner.cmd_opts).to include("--port 4000")
       expect(runner.cmd_opts).to include("--environment development")
       expect(runner.cmd_opts).to include("--quiet")
@@ -132,7 +132,7 @@ describe Guard::PumaRunner do
           it "assumes options are set in config" do
             expect(runner.cmd_opts).to match("--config #{path}")
             expect(runner.cmd_opts).to match(/--control-token [0-9a-f]{10,}/)
-            expect(runner.cmd_opts).to match("--control-url tcp")
+            expect(runner.cmd_opts).to match("--control tcp")
             expect(runner.cmd_opts).to match("--environment #{environment}")
           end
         end


### PR DESCRIPTION
Building off of @ianks's work in #43, this gets the tests passing with both Puma 4 and 5 (and has Travis test against both versions).

Here's an example half-failing build from before the final commit: https://travis-ci.org/github/michaelfairley/guard-puma/builds/741460935