### PR TITLE
Chore: bump max Puma version to 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,13 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.0'
+          - 3.1
+          - 3.0
           - 2.7
           - 2.6
           - 2.5
         puma_version:
+          - "~> 6.0"
           - "~> 5.0"
           - "~> 4.0"
     runs-on: ubuntu-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.8.0
+
+* Bump puma to 6.0
+
 ## 0.7.0
 
 * Add MIT license identifier in gemspec. Via #45

--- a/guard-puma.gemspec
+++ b/guard-puma.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Guard::PumaVersion::VERSION
   gem.add_dependency              "guard", "~> 2.14"
   gem.add_dependency              "guard-compat", "~> 1.2"
-  gem.add_dependency              "puma", ENV["PUMA_VERSION"] || [">= 4.0", "< 6"]
+  gem.add_dependency              "puma", ENV["PUMA_VERSION"] || [">= 4.0", "< 7"]
   gem.add_development_dependency  "rake", "~> 12"
   gem.add_development_dependency  "rspec", "~> 3.7"
   gem.add_development_dependency  "guard-rspec", "~> 4.7"

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'puma/detect'
 require 'puma/configuration'
 
 module Guard

--- a/lib/guard/puma/version.rb
+++ b/lib/guard/puma/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module PumaVersion
-    VERSION = "0.7.0"
+    VERSION = "0.8.0"
   end
 end


### PR DESCRIPTION
With the new Puma release, I'm proposing a bump of the max Puma version to 6.0. 

Due to a slight change of logic in Puma  - using `Puma.mri?` in a constant ([Puma::Configuration](https://github.com/puma/puma/compare/v5.0.0...v6.0.0#diff-2dc4e3e83be7fd97cebc482ae07d6a8216944003de82458783fb00b5ae9524c8R147)) I needed to introduce explicit `require 'puma/detect'` otherwise we will see 

```ruby
An error occurred while loading ./spec/lib/guard/puma/runner_spec.rb.
Failure/Error: require 'puma/configuration'

NoMethodError:
  undefined method `mri?' for Puma:Module
# /usr/local/bundle/gems/puma-6.0.0/lib/puma/configuration.rb:147:in `<class:Configuration>'
# /usr/local/bundle/gems/puma-6.0.0/lib/puma/configuration.rb:128:in `<module:Puma>'
# /usr/local/bundle/gems/puma-6.0.0/lib/puma/configuration.rb:8:in `<top (required)>'
# ./lib/guard/puma/runner.rb:2:in `require'
# ./lib/guard/puma/runner.rb:2:in `<top (required)>'
# ./spec/lib/guard/puma/runner_spec.rb:2:in `require'
# ./spec/lib/guard/puma/runner_spec.rb:2:in `<top (required)>'

An error occurred while loading ./spec/lib/guard/puma_spec.rb.
Failure/Error: require 'puma/configuration'

NoMethodError:
  undefined method `mri?' for Puma:Module
# /usr/local/bundle/gems/puma-6.0.0/lib/puma/configuration.rb:147:in `<class:Configuration>'
# /usr/local/bundle/gems/puma-6.0.0/lib/puma/configuration.rb:128:in `<module:Puma>'
# /usr/local/bundle/gems/puma-6.0.0/lib/puma/configuration.rb:8:in `<top (required)>'
# ./lib/guard/puma/runner.rb:2:in `require'
# ./lib/guard/puma/runner.rb:2:in `<top (required)>'
# ./lib/guard/puma.rb:2:in `require_relative'
# ./lib/guard/puma.rb:2:in `<top (required)>'
# ./spec/lib/guard/puma_spec.rb:2:in `require'
# ./spec/lib/guard/puma_spec.rb:2:in `<top (required)>'
Run options: include {:focus=>true}
```

The change itself is backward compatible as `puma/detect` exists in [v4.0.0](https://github.com/puma/puma/blob/v4.0.0/lib/puma/detect.rb)

Tested via:

<details>
  <summary>PUMA_VERSION='~> 6.0'</summary>

```sh
root@0aee3b50d6da:/usr/src/app# PUMA_VERSION='~> 6.0' bundle install -j4
Fetching gem metadata from https://rubygems.org/.............
Resolving dependencies...
Using rake 12.3.3
Using bundler 2.2.33
Using coderay 1.1.3
Using diff-lcs 1.5.0
Using lumberjack 1.2.8
Using nenv 0.3.0
Using shellany 0.0.1
Using method_source 1.0.0
Using thor 1.2.1
Using guard-compat 1.2.1
Using nio4r 2.5.8
Using ffi 1.15.5
Using formatador 1.1.0
Using pry 0.14.1
Using rb-inotify 0.10.1
Using puma 6.0.0
Using rspec-support 3.11.1
Using notiffany 0.1.3
Using rspec-core 3.11.0
Using rspec-expectations 3.11.1
Using rb-fsevent 0.11.2
Using rspec-mocks 3.11.2
Using rspec 3.11.0
Using listen 3.7.1
Using guard 2.18.0
Using guard-puma 0.8.0 from source at `.`
Using guard-rspec 4.7.3
Bundle complete! 4 Gemfile dependencies, 27 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
root@0aee3b50d6da:/usr/src/app# bundle exec rake
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.11.0/lib:/usr/local/bundle/gems/rspec-support-3.11.1/lib /usr/local/bundle/gems/rspec-core-3.11.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
........................................

Finished in 2.58 seconds (files took 0.16076 seconds to load)
40 examples, 0 failures
```

</details>

<details>
  <summary>PUMA_VERSION='~> 5.0'</summary>

```sh
root@0aee3b50d6da:/usr/src/app# PUMA_VERSION='~> 5.0' bundle install -j4
Fetching gem metadata from https://rubygems.org/.............
Resolving dependencies...
Using rake 12.3.3
Using bundler 2.2.33
Using coderay 1.1.3
Using diff-lcs 1.5.0
Using ffi 1.15.5
Using formatador 1.1.0
Using rb-fsevent 0.11.2
Using lumberjack 1.2.8
Using nenv 0.3.0
Using method_source 1.0.0
Using nio4r 2.5.8
Using shellany 0.0.1
Using guard-compat 1.2.1
Using thor 1.2.1
Using rspec-support 3.11.1
Fetching puma 5.6.5
Using pry 0.14.1
Using rb-inotify 0.10.1
Using rspec-expectations 3.11.1
Using notiffany 0.1.3
Using rspec-mocks 3.11.2
Using listen 3.7.1
Using rspec-core 3.11.0
Using rspec 3.11.0
Using guard 2.18.0
Using guard-rspec 4.7.3
Installing puma 5.6.5 with native extensions
Using guard-puma 0.8.0 from source at `.`
Bundle complete! 4 Gemfile dependencies, 27 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
root@0aee3b50d6da:/usr/src/app# bundle exec rake
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.11.0/lib:/usr/local/bundle/gems/rspec-support-3.11.1/lib /usr/local/bundle/gems/rspec-core-3.11.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
........................................

Finished in 2.57 seconds (files took 0.14713 seconds to load)
40 examples, 0 failures
```

</details>

<details>
  <summary>PUMA_VERSION='~> 4.0'</summary>

```sh
root@0aee3b50d6da:/usr/src/app# PUMA_VERSION='~> 4.0' bundle install -j4
Fetching gem metadata from https://rubygems.org/.............
Resolving dependencies...
Using rake 12.3.3
Using bundler 2.2.33
Using coderay 1.1.3
Using diff-lcs 1.5.0
Using ffi 1.15.5
Using formatador 1.1.0
Using rb-fsevent 0.11.2
Using lumberjack 1.2.8
Using nenv 0.3.0
Using shellany 0.0.1
Using method_source 1.0.0
Using rspec-support 3.11.1
Using rb-inotify 0.10.1
Using notiffany 0.1.3
Using pry 0.14.1
Using thor 1.2.1
Using guard-compat 1.2.1
Using nio4r 2.5.8
Using listen 3.7.1
Using rspec-expectations 3.11.1
Using guard 2.18.0
Using rspec-core 3.11.0
Fetching puma 4.3.12
Using rspec-mocks 3.11.2
Using rspec 3.11.0
Using guard-rspec 4.7.3
Installing puma 4.3.12 with native extensions
Using guard-puma 0.8.0 from source at `.`
Bundle complete! 4 Gemfile dependencies, 27 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
root@0aee3b50d6da:/usr/src/app# bundle exec rake
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.11.0/lib:/usr/local/bundle/gems/rspec-support-3.11.1/lib /usr/local/bundle/gems/rspec-core-3.11.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
........................................

Finished in 2.6 seconds (files took 0.14184 seconds to load)
40 examples, 0 failures
```
</details>

@jc00ke let me know if there is more I should do 🙇🏻 
