### PR TITLE
Fix sh command for directories with spaces on unix-based systems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* Fix sh command for directories with spaces on unix-based systems
+
 ## 0.8.0
 
 * Bump puma to 6.0

--- a/lib/guard/puma/runner.rb
+++ b/lib/guard/puma/runner.rb
@@ -121,7 +121,7 @@ module Guard
     end
 
     def nix_cmd(puma_cmd, background = false)
-      %(sh -c 'cd #{Dir.pwd} && #{puma_cmd} #{'&' if background}')
+      %(sh -c 'cd "#{Dir.pwd}" && #{puma_cmd} #{'&' if background}')
     end
 
     def windows_cmd(puma_cmd, background = false)

--- a/spec/lib/guard/puma/runner_spec.rb
+++ b/spec/lib/guard/puma/runner_spec.rb
@@ -50,7 +50,7 @@ describe Guard::PumaRunner do
         end
 
         let(:command) {
-          %(sh -c 'cd #{Dir.pwd} && pumactl #{runner.cmd_opts} #{cmd} ')
+          %(sh -c 'cd "#{Dir.pwd}" && pumactl #{runner.cmd_opts} #{cmd} ')
         }
 
         it "#{cmd}s" do


### PR DESCRIPTION
Hello!
I noticed that guard-puma is failing when there is a space in the directory on my Mac