### PR TITLE
chore: bump max puma version to 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,26 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 3.4
+          - 3.3
+          - 3.2
           - 3.1
           - 3.0
           - 2.7
           - 2.6
           - 2.5
         puma_version:
+          - "~> 7.0"
           - "~> 6.0"
           - "~> 5.0"
           - "~> 4.0"
+        exclude:
+          - ruby: 2.7
+            puma_version: "~> 7.0"
+          - ruby: 2.6
+            puma_version: "~> 7.0"
+          - ruby: 2.5
+            puma_version: "~> 7.0"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.9.0
+
+- Bump puma to 7.0
+
 ## 0.8.1
 
 - Fix sh command for directories with spaces on unix-based systems

--- a/guard-puma.gemspec
+++ b/guard-puma.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Guard::PumaVersion::VERSION
   gem.add_dependency              "guard", "~> 2.14"
   gem.add_dependency              "guard-compat", "~> 1.2"
-  gem.add_dependency              "puma", ENV["PUMA_VERSION"] || [">= 4.0", "< 7"]
+  gem.add_dependency              "puma", ENV["PUMA_VERSION"] || [">= 4.0", "< 8"]
   gem.add_development_dependency  "rake", "~> 12"
   gem.add_development_dependency  "rspec", "~> 3.7"
   gem.add_development_dependency  "guard-rspec", "~> 4.7"

--- a/lib/guard/puma/version.rb
+++ b/lib/guard/puma/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module PumaVersion
-    VERSION = '0.8.1'
+    VERSION = '0.9.0'
   end
 end


### PR DESCRIPTION
This change allows puma 7 as a dependency and adds the more recent ruby versions to the test matrix.
Since puma 7 has a minimum ruby version requirement of 3, I have added the necessary exclusions to only test valid puma/ruby combinations.

I had considered removing EOL ruby versions from the test matrix to keep the number of jobs down, but I wanted to keep the changes to the minimum required to get this gem to work with puma 7.