### PR TITLE
Remove eol'd ruby versions from ci matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,23 +9,11 @@ jobs:
           - 3.4
           - 3.3
           - 3.2
-          - 3.1
-          - 3.0
-          - 2.7
-          - 2.6
-          - 2.5
         puma_version:
           - "~> 7.0"
           - "~> 6.0"
           - "~> 5.0"
           - "~> 4.0"
-        exclude:
-          - ruby: 2.7
-            puma_version: "~> 7.0"
-          - ruby: 2.6
-            puma_version: "~> 7.0"
-          - ruby: 2.5
-            puma_version: "~> 7.0"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
As mentioned in  #50, here's the PR that removes old versions of ruby from the ci matrix.

Source for the EOL dates: https://www.ruby-lang.org/en/downloads/branches/